### PR TITLE
Stop using GNU extensions for stat calls

### DIFF
--- a/doc-src/asciiart/start
+++ b/doc-src/asciiart/start
@@ -1,17 +1,11 @@
 #!/bin/sh
 
-if [ "$(uname)" = "Darwin" ]; then
-  STATCMD='stat -f'
-else
-  STATCMD='stat -c'
-fi
-
 DIR=./deck/
 mkdir -p $DIR
-if [ $(${STATCMD} "%u" $DIR) -eq 0 ]; then
+if [ $(ls -ld $DIR | awk '{print $3}') != $USER ]; then
     echo "[ERR] The output folder '$DIR' MUST be owned by you!"
     echo "[ERR] Please change ownership to yourself ('sudo chown $USER $DIR'), or"
     echo "[ERR] remove '$DIR' completely ('sudo rm -rf $DIR')."
     exit 1
 fi
-MARKDECK_USER=$(${STATCMD} "%u:%g" $DIR) docker-compose up
+MARKDECK_USER=$(ls -ldn $DIR | awk '{print $3 ":" $4}') docker-compose up

--- a/doc-src/asciiart/start
+++ b/doc-src/asciiart/start
@@ -1,11 +1,17 @@
 #!/bin/sh
 
+if [ "$(uname)" = "Darwin" ]; then
+  STATCMD='stat -f'
+else
+  STATCMD='stat -c'
+fi
+
 DIR=./deck/
 mkdir -p $DIR
-if [ $(stat -c "%u" $DIR) -eq 0 ]; then
+if [ $(${STATCMD} "%u" $DIR) -eq 0 ]; then
     echo "[ERR] The output folder '$DIR' MUST be owned by you!"
     echo "[ERR] Please change ownership to yourself ('sudo chown $USER $DIR'), or"
     echo "[ERR] remove '$DIR' completely ('sudo rm -rf $DIR')."
     exit 1
 fi
-MARKDECK_USER=$(stat -c "%u:%g" $DIR) docker-compose up
+MARKDECK_USER=$(${STATCMD} "%u:%g" $DIR) docker-compose up

--- a/doc-src/markdown-basics/start
+++ b/doc-src/markdown-basics/start
@@ -1,17 +1,11 @@
 #!/bin/sh
 
-if [ "$(uname)" = "Darwin" ]; then
-  STATCMD='stat -f'
-else
-  STATCMD='stat -c'
-fi
-
 DIR=./deck/
 mkdir -p $DIR
-if [ $(${STATCMD} "%u" $DIR) -eq 0 ]; then
+if [ $(ls -ld $DIR | awk '{print $3}') != $USER ]; then
     echo "[ERR] The output folder '$DIR' MUST be owned by you!"
     echo "[ERR] Please change ownership to yourself ('sudo chown $USER $DIR'), or"
     echo "[ERR] remove '$DIR' completely ('sudo rm -rf $DIR')."
     exit 1
 fi
-MARKDECK_USER=$(${STATCMD} "%u:%g" $DIR) docker-compose up
+MARKDECK_USER=$(ls -ldn $DIR | awk '{print $3 ":" $4}') docker-compose up

--- a/doc-src/markdown-basics/start
+++ b/doc-src/markdown-basics/start
@@ -1,11 +1,17 @@
 #!/bin/sh
 
+if [ "$(uname)" = "Darwin" ]; then
+  STATCMD='stat -f'
+else
+  STATCMD='stat -c'
+fi
+
 DIR=./deck/
 mkdir -p $DIR
-if [ $(stat -c "%u" $DIR) -eq 0 ]; then
+if [ $(${STATCMD} "%u" $DIR) -eq 0 ]; then
     echo "[ERR] The output folder '$DIR' MUST be owned by you!"
     echo "[ERR] Please change ownership to yourself ('sudo chown $USER $DIR'), or"
     echo "[ERR] remove '$DIR' completely ('sudo rm -rf $DIR')."
     exit 1
 fi
-MARKDECK_USER=$(stat -c "%u:%g" $DIR) docker-compose up
+MARKDECK_USER=$(${STATCMD} "%u:%g" $DIR) docker-compose up

--- a/example/minimal/start
+++ b/example/minimal/start
@@ -1,17 +1,11 @@
 #!/bin/sh
 
-if [ "$(uname)" = "Darwin" ]; then
-  STATCMD='stat -f'
-else
-  STATCMD='stat -c'
-fi
-
 DIR=./deck/
 mkdir -p $DIR
-if [ $(${STATCMD} "%u" $DIR) -eq 0 ]; then
+if [ $(ls -ld $DIR | awk '{print $3}') != $USER ]; then
     echo "[ERR] The output folder '$DIR' MUST be owned by you!"
     echo "[ERR] Please change ownership to yourself ('sudo chown $USER $DIR'), or"
     echo "[ERR] remove '$DIR' completely ('sudo rm -rf $DIR')."
     exit 1
 fi
-MARKDECK_USER=$(${STATCMD} "%u:%g" $DIR) docker-compose up
+MARKDECK_USER=$(ls -ldn $DIR | awk '{print $3 ":" $4}') docker-compose up

--- a/example/minimal/start
+++ b/example/minimal/start
@@ -1,11 +1,17 @@
 #!/bin/sh
 
+if [ "$(uname)" = "Darwin" ]; then
+  STATCMD='stat -f'
+else
+  STATCMD='stat -c'
+fi
+
 DIR=./deck/
 mkdir -p $DIR
-if [ $(stat -c "%u" $DIR) -eq 0 ]; then
+if [ $(${STATCMD} "%u" $DIR) -eq 0 ]; then
     echo "[ERR] The output folder '$DIR' MUST be owned by you!"
     echo "[ERR] Please change ownership to yourself ('sudo chown $USER $DIR'), or"
     echo "[ERR] remove '$DIR' completely ('sudo rm -rf $DIR')."
     exit 1
 fi
-MARKDECK_USER=$(stat -c "%u:%g" $DIR) docker-compose up
+MARKDECK_USER=$(${STATCMD} "%u:%g" $DIR) docker-compose up

--- a/example/start
+++ b/example/start
@@ -1,17 +1,11 @@
 #!/bin/sh
 
-if [ "$(uname)" = "Darwin" ]; then
-  STATCMD='stat -f'
-else
-  STATCMD='stat -c'
-fi
-
 DIR=./deck/
 mkdir -p $DIR
-if [ $(${STATCMD} "%u" $DIR) -eq 0 ]; then
+if [ $(ls -ld $DIR | awk '{print $3}') != $USER ]; then
     echo "[ERR] The output folder '$DIR' MUST be owned by you!"
     echo "[ERR] Please change ownership to yourself ('sudo chown $USER $DIR'), or"
     echo "[ERR] remove '$DIR' completely ('sudo rm -rf $DIR')."
     exit 1
 fi
-MARKDECK_USER=$(${STATCMD} "%u:%g" $DIR) docker-compose up
+MARKDECK_USER=$(ls -ldn $DIR | awk '{print $3 ":" $4}') docker-compose up

--- a/example/start
+++ b/example/start
@@ -1,11 +1,17 @@
 #!/bin/sh
 
+if [ "$(uname)" = "Darwin" ]; then
+  STATCMD='stat -f'
+else
+  STATCMD='stat -c'
+fi
+
 DIR=./deck/
 mkdir -p $DIR
-if [ $(stat -c "%u" $DIR) -eq 0 ]; then
+if [ $(${STATCMD} "%u" $DIR) -eq 0 ]; then
     echo "[ERR] The output folder '$DIR' MUST be owned by you!"
     echo "[ERR] Please change ownership to yourself ('sudo chown $USER $DIR'), or"
     echo "[ERR] remove '$DIR' completely ('sudo rm -rf $DIR')."
     exit 1
 fi
-MARKDECK_USER=$(stat -c "%u:%g" $DIR) docker-compose up
+MARKDECK_USER=$(${STATCMD} "%u:%g" $DIR) docker-compose up


### PR DESCRIPTION
On Darwin/MacOS, that `stat` call has a somewhat different syntax, as GNU/Linux uses GNU extensions instead of POSIX syntax.

While using `gstat` would be possible, this PR uses `ls` without GNU extensions, fixing the problem of `./start` complaining about argument errors.