### PR TITLE
Theming

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -27,6 +27,7 @@ prepare:	downloaded/bin/pandoc \
 	markdeck/assets/3rdparty/asciinema-player.js \
 	markdeck/assets/3rdparty/asciinema-player.css \
 	markdeck/assets/3rdparty/reveal.js \
+	markdeck/assets/3rdparty/reveal.js/css/theme/source/markdeck.scss \
 	markdeck/assets/3rdparty/impress.js \
 	jqueryemoji \
 	markdeck/helper/downloaded/trianglify-background-generator-master \
@@ -90,6 +91,8 @@ markdeck/assets/3rdparty/reveal.js:
 	mkdir -p $@
 	curl -L "https://github.com/hakimel/reveal.js/archive/$(REVEALJS_VERSION).tar.gz" | tar -C $@ --strip-components=1 --exclude test --exclude font -zxvf -
 
+markdeck/assets/3rdparty/reveal.js/css/theme/source/markdeck.scss: markdeck/assets/markdeck/css/theme/source/markdeck.scss
+	cp $^ $@
 
 markdeck/assets/3rdparty/impress.js:
 	mkdir -p $@

--- a/src/Makefile
+++ b/src/Makefile
@@ -22,7 +22,6 @@ push:	all
 
 prepare:	downloaded/bin/pandoc \
 	markdeck/lib/plantuml.jar \
-	markdeck/lib/plantuml.jar \
 	markdeck/lib/ditaa.jar \
 	markdeck/assets/3rdparty/asciinema-player.js \
 	markdeck/assets/3rdparty/asciinema-player.css \

--- a/src/markdeck/assets/markdeck/css/_common.scss
+++ b/src/markdeck/assets/markdeck/css/_common.scss
@@ -1,43 +1,6 @@
-img.emoji {
-    width: 1.1em;
-    height: 1.1em;
-    padding: 0;
-    margin: 0;
-    vertical-align: baseline;
-}
-
-.rerendering-message {
-    display: none;
-    position: absolute;
-    text-align: center;
-    top: 20%;
-    left: 0;
-    width: 100%;
-    height: 100vh;
-    z-index: 1000;
-    color: white;
-    font-size: 200%;
-    text-shadow: 2px 2px #000000;
-}
-
-.markdeck-logo {
-    position: absolute;
-    left: 0;
-    right: 0;
-    text-align: center;
-    bottom: 8px;
-    height: 8px;
-    font-size: 10px;
-    color: #5550;
-    z-index: 1;
-
-    a {
-        color: #333a;
-        text-shadow: 1px 1px #bbba;
-        background: none;
-        text-decoration: none;
-    }
-}
+// FIXME this is just the remainder of what has been moved into markdeck.scss
+// for revealjs but not yet for impressjs.
+@import "commoncommon";
 
 .light-on-dark, section.light-on-dark h1 {
     color: #fff;
@@ -51,36 +14,6 @@ img.emoji {
     }
 }
 
-/*!
- * Font Awesome Free 5.5.0 by @fontawesome - https://fontawesome.com
- * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
- */
-@font-face {
-    font-family: "Font Awesome 5 Brands";
-    font-style: normal;
-    font-weight: normal;
-    src: url(fonts/fa-brands-400.ttf) format("truetype");
-}
-.fab {
-    font-family:"Font Awesome 5 Brands";
-}
-
-/*!
- * Font Awesome Free 5.5.0 by @fontawesome - https://fontawesome.com
- * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
- */
-@font-face {
-    font-family: "Font Awesome 5 Free";
-    font-style: normal;
-    font-weight: 900;
-    src: url(fonts/fa-solid-900.ttf) format("truetype");
-}
-.fa, .fas {
-    font-family:"Font Awesome 5 Free";
-    font-weight:900;
-}
-
-@import "fontawesome.css";
 
 @font-face {
     font-family: 'Inconsolata';

--- a/src/markdeck/assets/markdeck/css/_commoncommon.scss
+++ b/src/markdeck/assets/markdeck/css/_commoncommon.scss
@@ -4,6 +4,7 @@ img.emoji {
     padding: 0;
     margin: 0;
     vertical-align: baseline;
+    box-shadow: none;
 }
 
 .rerendering-message {
@@ -49,7 +50,6 @@ img.emoji {
     font-weight: normal;
     src: url(fonts/fa-brands-400.ttf) format("truetype");
 }
-
 .fab {
     font-family:"Font Awesome 5 Brands";
 }

--- a/src/markdeck/assets/markdeck/css/_commoncommon.scss
+++ b/src/markdeck/assets/markdeck/css/_commoncommon.scss
@@ -1,12 +1,3 @@
-img.emoji {
-    width: 1.1em;
-    height: 1.1em;
-    padding: 0;
-    margin: 0;
-    vertical-align: baseline;
-    box-shadow: none;
-}
-
 .rerendering-message {
     display: none;
     position: absolute;

--- a/src/markdeck/assets/markdeck/css/_commoncommon.scss
+++ b/src/markdeck/assets/markdeck/css/_commoncommon.scss
@@ -1,0 +1,72 @@
+img.emoji {
+    width: 1.1em;
+    height: 1.1em;
+    padding: 0;
+    margin: 0;
+    vertical-align: baseline;
+}
+
+.rerendering-message {
+    display: none;
+    position: absolute;
+    text-align: center;
+    top: 20%;
+    left: 0;
+    width: 100%;
+    height: 100vh;
+    z-index: 1000;
+    color: white;
+    font-size: 200%;
+    text-shadow: 2px 2px #000000;
+}
+
+.markdeck-logo {
+    position: absolute;
+    left: 0;
+    right: 0;
+    text-align: center;
+    bottom: 8px;
+    height: 8px;
+    font-size: 10px;
+    color: #5550;
+    z-index: 1;
+
+    a {
+        color: #333a;
+        text-shadow: 1px 1px #bbba;
+        background: none;
+        text-decoration: none;
+    }
+}
+
+/*!
+ * Font Awesome Free 5.5.0 by @fontawesome - https://fontawesome.com
+ * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+ */
+@font-face {
+    font-family: "Font Awesome 5 Brands";
+    font-style: normal;
+    font-weight: normal;
+    src: url(fonts/fa-brands-400.ttf) format("truetype");
+}
+
+.fab {
+    font-family:"Font Awesome 5 Brands";
+}
+
+/*!
+ * Font Awesome Free 5.5.0 by @fontawesome - https://fontawesome.com
+ * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+ */
+@font-face {
+    font-family: "Font Awesome 5 Free";
+    font-style: normal;
+    font-weight: 900;
+    src: url(fonts/fa-solid-900.ttf) format("truetype");
+}
+.fa, .fas {
+    font-family:"Font Awesome 5 Free";
+    font-weight:900;
+}
+
+@import "fontawesome.css";

--- a/src/markdeck/assets/markdeck/css/markdeck.revealjs.scss
+++ b/src/markdeck/assets/markdeck/css/markdeck.revealjs.scss
@@ -1,24 +1,7 @@
-@import "common";
-
-.reveal {
-    h1, h2, h3, h4, h5, h6, div {
-        font-family: sans-serif;
-    }
-}
-
-.reveal h1 {
-    font-size: 1.4em; }
-
-.reveal h2 {
-    font-size: 0.8em; }
+@import "commoncommon";
 
 .reveal .license {
     font-size: 12pt;
-}
-
-.reveal section img {
-    border: 0;
-    background: transparent;
 }
 
 .reveal .footer {
@@ -26,35 +9,6 @@
     bottom: 1em;
     left: 1em;
     font-size: 0.5em;
-}
-
-.reveal .controls .navigate-up.enabled {
-    border-bottom-color: #444;
-}
-
-.reveal .controls .navigate-down.enabled {
-    border-top-color: #444;
-}
-
-.reveal .controls .navigate-right.enabled {
-    border-left-color: #444;
-}
-
-.reveal .controls .navigate-left.enabled {
-    border-right-color: #444;
-}
-
-.reveal .progress span {
-    background: #444;
-}
-
-.reveal section img {
-    box-shadow: none;
-}
-
-.slide-background {
-    background-size: cover !important;
-    background-repeat: no-repeat;
 }
 
 .reveal img.emoji {
@@ -65,14 +19,6 @@
     vertical-align: baseline;
 }
 
-section.has-dark-background.colorfull * {
-    // text-shadow: 1px 1px #000;
-}
-
-section.has-dark-background.colorfull a {
-    color: AliceBlue;
-}
-
 .flush-text-left {
     text-align: left;
 }
@@ -80,3 +26,9 @@ section.has-dark-background.colorfull a {
 .rerendering-message {
     display: none;
 }
+
+.reveal section img {
+    border: 0;
+    background: transparent;
+}
+

--- a/src/markdeck/assets/markdeck/css/markdeck.revealjs.scss
+++ b/src/markdeck/assets/markdeck/css/markdeck.revealjs.scss
@@ -33,3 +33,6 @@
     background: transparent;
 }
 
+.notes .reveal .controls {
+    display: contents !important;
+}

--- a/src/markdeck/assets/markdeck/css/markdeck.revealjs.scss
+++ b/src/markdeck/assets/markdeck/css/markdeck.revealjs.scss
@@ -17,6 +17,7 @@
     padding: 0;
     margin: 0;
     vertical-align: baseline;
+    box-shadow: none;
 }
 
 .flush-text-left {

--- a/src/markdeck/assets/markdeck/css/theme/source/markdeck.scss
+++ b/src/markdeck/assets/markdeck/css/theme/source/markdeck.scss
@@ -1,0 +1,119 @@
+/**
+ * Markdeck theme for reveal.js presentations, similar
+ * to the simple theme. The accent color is darkblue.
+ *
+ * reveal.js is Copyright (C) 2011-2012 Hakim El Hattab, http://hakim.se
+ */
+
+
+// Default mixins and settings -----------------
+@import "../template/mixins";
+@import "../template/settings";
+// ---------------------------------------------
+
+// Include theme-specific fonts
+@font-face {
+    font-family: 'Inconsolata';
+    font-style: normal;
+    font-weight: 400;
+    src: url("fonts/Inconsolata-Regular.ttf") format('truetype');
+}
+
+@font-face {
+    font-family: "EB Garamond Bold";
+    font-style: normal;
+    font-weight: 400;
+    src: url("fonts/EBGaramond-Bold.ttf") format('truetype');
+}
+
+@font-face {
+    font-family: "xkcd Script";
+    font-style: normal;
+    font-weight: 400;
+    src: url("fonts/xkcd-script.ttf") format('truetype');
+}
+
+@font-face {
+    font-family: 'Raleway';
+    font-style: normal;
+    font-weight: 400;
+    src: url("fonts/Raleway-Regular.ttf") format('truetype');
+}
+
+// Override theme settings (see ../template/settings.scss)
+$mainFont: 'Lato', sans-serif;
+$mainColor: #000;
+$headingFont: sans-serif;
+$headingColor: #000;
+$headingTextShadow: none;
+$headingTextTransform: none;
+$backgroundColor: #fff;
+$linkColor: #00008B;
+$linkColorHover: lighten( $linkColor, 20% );
+$selectionBackgroundColor: rgba(0, 0, 0, 0.99);
+
+$heading1Size: 1.4em;
+$heading2Size: 0.8em;
+$heading3Size: 0.8em;
+$heading4Size: 0.8em;
+
+section.has-dark-background {
+	&, h1, h2, h3, h4, h5, h6 {
+		color: #fff;
+	}
+}
+
+.slide-background {
+    background-size: cover !important;
+    background-repeat: no-repeat;
+}
+
+.light-on-dark, section.light-on-dark h1 {
+    color: #fff;
+    text-shadow: 0px 1px #000;
+}
+
+section.has-dark-background.colorfull * {
+    // text-shadow: 1px 1px #000;
+}
+
+section.has-dark-background.colorfull a {
+    color: AliceBlue;
+}
+
+.ltr, .inline {
+    p, pre {
+        display: inline-block;
+        vertical-align: middle;
+    }
+}
+
+// Theme template ------------------------------
+@import "../template/theme";
+// ---------------------------------------------
+
+// Override some settings from theme
+.reveal section img {
+    box-shadow: none;
+}
+
+.reveal .progress span {
+    background: #444;
+}
+
+.reveal .controls .navigate-up.enabled {
+    border-bottom-color: #444;
+}
+
+.reveal .controls .navigate-down.enabled {
+    border-top-color: #444;
+}
+
+.reveal .controls .navigate-right.enabled {
+    border-left-color: #444;
+}
+
+.reveal .controls .navigate-left.enabled {
+    border-right-color: #444;
+}
+

--- a/src/markdeck/defaults.yaml
+++ b/src/markdeck/defaults.yaml
@@ -22,7 +22,7 @@ standalone:
 
 asciinema: false
 
-theme: black
+theme: markdeck
 themePath: assets/3rdparty/reveal.js/css/theme
 transition: slide
 controls: false

--- a/src/markdeck/loop
+++ b/src/markdeck/loop
@@ -82,6 +82,9 @@ while true; do
         /markdeck/assets/markdeck/css/markdeck.revealjs.scss \
         /target/assets/markdeck/css/markdeck.revealjs.css || :
     sassc \
+        /markdeck/assets/3rdparty/reveal.js/css/theme/source/markdeck.scss \
+        /target/assets/3rdparty/reveal.js/css/theme/markdeck.css || :
+    sassc \
         /markdeck/assets/markdeck/css/markdeck.impressjs.scss \
         /target/assets/markdeck/css/markdeck.impressjs.css || :
     echo "-------- /sass output --------"

--- a/src/markdeck/loop
+++ b/src/markdeck/loop
@@ -73,6 +73,14 @@ while true; do
             /source/assets/css/slides.scss \
             /target/assets/css/slides.css || :
     fi
+    if [[ -e /source/assets/css/theme/source/ ]]; then
+        find /source/assets/css/theme/source/ -name \*.scss | while read filename; do
+            cp "$filename" /target/assets/3rdparty/reveal.js/css/theme/source/
+            sassc \
+                /target/assets/3rdparty/reveal.js/css/theme/source/$(basename "$filename") \
+                /target/assets/3rdparty/reveal.js/css/theme/$(basename "$filename" | sed -e 's/\.scss$/.css/') || :
+        done
+    fi
     if [[ -e /source/assets/css/slides.impress.scss ]]; then
         sassc \
             /source/assets/css/slides.impress.scss \

--- a/src/markdeck/template-reveal.html
+++ b/src/markdeck/template-reveal.html
@@ -15,6 +15,7 @@
 
     <link rel="stylesheet" href="assets/3rdparty/reveal.js/css/reveal.css" />
     <link rel="stylesheet" href="$themePath$/$theme$.css" id="theme" />
+    <link rel="shortcut icon" href="assets/css/theme/favicon.ico" />
 
     <link rel="stylesheet" href="assets/markdeck/styles/$highlight_style$.css" />
 

--- a/src/markdeck/template-reveal.html
+++ b/src/markdeck/template-reveal.html
@@ -130,6 +130,12 @@ $body$
     <script src="assets/markdeck/revealjs-helper.js"></script>
     <script>
         flushleft(".slides .flushleft");
+
+        // add notes class to make sure controls are always displayed on the
+        // speaker notes
+        if (window.self !== window.top) {
+            document.body.className += " notes";
+        }
     </script>
 
 $for(include-after)$

--- a/src/markdeck/template-reveal.html
+++ b/src/markdeck/template-reveal.html
@@ -49,6 +49,9 @@ $endfor$
     <div class="markdeck-logo"><a href="https://github.com/arnehilmann/markdeck">powered by markdeck</a></div>
     $endif$
 
+    <div class="header"></div>
+    <div class="footer"></div>
+
     <div class="reveal">
         <div class="slides">
 


### PR DESCRIPTION
I created a separate markdeck theme for revealjs from the specific styling that was present in markdeck.revealjs.scss and other files. This makes it easier to create custom themes because they don't have to replace everything markdeck defines.
Furthermore, I added functionality for putting custom revealjs themes in assets/css/theme/source - which is the default place for revealjs themes. Scss files in that folder will be copied into the 3rdparty/revealjs/... folder and compiled. This makes it easy to use custom revealjs themes with markdeck.