### PR TITLE
Add markdeck script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-# markdeck - presentations as code</br>
+# markdeck - presentations as code
 
 author cool slide decks, text-only, offline-ready, collaborative
-
 
 ![](https://img.shields.io/github/forks/arnehilmann/markdeck.svg)
 ![](https://img.shields.io/github/stars/arnehilmann/markdeck.svg)
@@ -33,15 +32,16 @@ or the [showcase](https://arnehilmann.github.io/markdeck/showcase/).
 
 ## install markdeck, tl;dr
 
-You need `bash`, `curl`, `docker-compose` and an empty directory, then run the following command:
+You need `bash`, `curl`, and `docker-compose`, then run the following
+commands that will download the docker images:
 ```
-curl https://raw.githubusercontent.com/arnehilmann/markdeck/master/scaffold | bash
+curl -LO https://raw.githubusercontent.com/arnehilmann/markdeck/master/markdeck
+chmod a+x markdeck
+./markdeck pull
 ```
 
-This will download a minimal setup, download all needed docker images,
-then markdeck gets started...
-
-Use `Ctrl-C` to stop markdeck, and `./start`, `./stop` or `./update-markdeck` to do the suitable things.
+The `markdeck` script can be stored in a folder in `$PATH` so that it
+can be executed from everywhere in the file system.
 
 
 ## documentation
@@ -51,19 +51,22 @@ Use `Ctrl-C` to stop markdeck, and `./start`, `./stop` or `./update-markdeck` to
 
 ## how to start from scratch
 
-```
-mkdir my-slides && cd my-slides
-curl -O https://raw.githubusercontent.com/arnehilmann/markdeck/master/scaffold
-./scaffold
-```
+Run the following command to create an empty presentation (if markdeck
+is not stored in `$PATH` prefix the command with `./`):
 
 ```
-open http://localhost:8080
+markdeck scaffold
 ```
 
+Run the following command to start markdeck:
+
 ```
+markdeck
+```
+
+Open the browser at `http://localhost:8080`.
+
 # edit slides.md, add assets/, consult documentation, ...
-```
 
 
 ## how does this work
@@ -89,7 +92,7 @@ at the [documentation](DOCUMENTATION.md).
 [asciitosvg](https://github.com/dhobsd/asciitosvg),
 [graphviz](https://www.graphviz.org/),
 [asciinema](https://asciinema.org/),
-[decktape](https://github.com/astefanutti/decktape), 
+[decktape](https://github.com/astefanutti/decktape),
 [vega-lite](https://vega.github.io/vega-lite/),
 [mathjax-pandoc-filter](https://www.npmjs.com/package/mathjax-pandoc-filter), and
 [font-awesome](https://fontawesome.com/).

--- a/markdeck
+++ b/markdeck
@@ -93,13 +93,12 @@ services:
         read_only: true
 EOF
 
-    # trap "rm -f '${tmpfile}'; exit" EXIT SIGHUP SIGTERM SIGINT SIGKILL SIGQUIT
-    trap "echo trap triggered 1>&2" EXIT SIGHUP SIGTERM SIGINT SIGKILL SIGQUIT
     echo "${tmpfile}"
 }
 
 dockerCompose () {
     composefile="$(createComposeFile)"
+    trap "rm -f '${composefile}'; exit" EXIT SIGHUP SIGTERM SIGINT SIGKILL SIGQUIT
     docker-compose -f "${composefile}" "${@}"
 }
 

--- a/markdeck
+++ b/markdeck
@@ -1,0 +1,289 @@
+#!/bin/bash
+# combined script that includes the docker-compose configuration
+set -ue
+
+BUILD=deck
+VERSION=0.1
+
+printHelp () {
+    echo "$(basename "$0") [-h|--help|-v|--version] [command]"
+    echo
+    echo "Commands:"
+    echo -e "\tstart: start markdeck server in the current folder (default)"
+    echo -e "\tstop: stop markdeck server"
+    echo -e "\tpull: pull docker images (this only has to happen once, at the start it will happen automatically)"
+    echo -e "\tupdate: update markdeck executable"
+    echo -e "\tscaffold: create an example presentation in the current folder"
+}
+
+printVersion () {
+    echo "$(basename "$0") v${VERSION}"
+}
+
+testOwnership () {
+    local dir="$1"
+    if [ $(stat -c %U "${dir}") != "${USER}" ]; then
+        echo "[ERR] The output folder '${dir}' MUST be owned by you!" 1>&2
+        echo "[ERR] Please change ownership to yourself ('sudo chown ${USER} ${dir}'), or" 1>&2
+        echo "[ERR] remove '${dir}' completely ('sudo rm -rf ${dir}')." 1>&2
+        exit 1
+    fi
+}
+
+createFolder () {
+    mkdir -p "${1}"
+}
+
+createComposeFile () {
+    tmpfile=$(mktemp)
+    cat > "${tmpfile}" << EOF
+version: "3.2"
+
+services:
+  markdeck:
+    image: "arne/markdeck-pandoc:0.34"
+    user: "\$MARKDECK_USER"
+    volumes:
+      - type: bind
+        source: $PWD/
+        target: /source
+        read_only: true
+      - type: bind
+        source: $PWD/$BUILD
+        target: /target
+
+  web:
+    image: "arne/markdeck-liveserver:0.2"
+    ports:
+      - "8080:8080"
+    volumes:
+      - type: bind
+        source: $PWD/$BUILD
+        target: /target
+    depends_on: [markdeck]
+
+  pdf:
+    image: "arne/markdeck-decktape:0.5"
+    volumes:
+      - type: bind
+        source: $PWD/$BUILD
+        target: /slides
+    shm_size: 1G
+    depends_on: [markdeck, web]
+
+  standalone:
+    image: "arne/markdeck-standalone:0.2"
+    volumes:
+      - type: bind
+        source: $PWD/$BUILD
+        target: /target
+    depends_on: [web]
+
+  helper:
+    image: "arne/markdeck-helper:0.2"
+    ports:
+      - "8081:8081"
+
+  a2sketch:
+    image: "arne/a2sketch:0.11"
+    volumes:
+      - type: bind
+        source: $PWD/a2s-custom-types
+        target: /custom-types
+        read_only: true
+EOF
+
+    # trap "rm -f '${tmpfile}'; exit" EXIT SIGHUP SIGTERM SIGINT SIGKILL SIGQUIT
+    trap "echo trap triggered 1>&2" EXIT SIGHUP SIGTERM SIGINT SIGKILL SIGQUIT
+    echo "${tmpfile}"
+}
+
+dockerCompose () {
+    composefile="$(createComposeFile)"
+    docker-compose -f "${composefile}" "${@}"
+}
+
+update () {
+    curl -# -S -f -L -O "${0}" https://raw.githubusercontent.com/arnehilmann/markdeck/master/markdeck
+    chmod a+x "${0}"
+    echo "Updated from $(printVersion) to $("${0}" --version)"
+}
+
+scaffold () {
+    mkdir -p assets/css
+    cat > slides.md << "EOF"
+---
+title: markdeck scaffold
+pdf: markdeck-scaffold.pdf
+slideNumber: true
+controls: true
+---
+
+# first slide {bg=#eee}
+
+made with [markdeck](https://arnehilmann.github.io/markdeck/){target="_blank"}
+
+```render_a2s
+#----------.
+|[markdeck]|
+'----------#
+[markdeck]: {"fill": "Teal", "fillStyle": "solid"}
+```
+
+<small>
+interesting links:
+  [your main deck](/){target="_parent"}
+• [markdown/slide side-by-side](/explain.html)
+• [utilities](//localhost:8081/){target="_blank"}
+</small>
+
+⚪ ⚪ ⚪
+EOF
+
+    cat > assets/explain.html << "EOF"
+<html>
+<head>
+    <style>
+        body {
+            margin: 0;
+        }
+        .box {
+            display:inline-block;
+            padding: 0;
+        }
+        .deck {
+            width: 60%;
+        }
+        .source {
+            width: 38%;
+            border-left: 4px dashed #ccc;
+        }
+
+    </style>
+</head>
+<body>
+    <div class="box deck">
+        <iframe
+            id="deck"
+            src="index.html?in_explain"
+            style="border: 0;"
+            frameborder="0"
+            scrolling="no" height="100%" width="100%" align="left" ></iframe>
+    </div>
+    <div class="box source">
+        <iframe
+            id="source"
+            src="slides.combined.md.txt"
+            frameborder="0"
+            height="100%" width="100%" align="left" ></iframe>
+    </div>
+
+    <script>
+        var deck = document.getElementById('deck');
+        var source = document.getElementById('source');
+
+        var split_source = function(doc) {
+            // console.log(doc);
+            var myText = doc.getElementsByTagName("pre")[0];
+            // console.log(myText);
+            var lines = myText.innerHTML.split("\n");
+            var numLines = lines.length;
+            var i;
+            var currentSection = undefined;
+            var header = false;
+
+            window.sections = Array();
+
+            for (i = 0; i < numLines; i++) {
+                var line = lines[i];
+                // console.log("line: " + line);
+                if (line.indexOf('---') == 0) {
+                    header = !header;
+                    continue;
+                }
+                if (header) {
+                    continue;
+                }
+                if (line.indexOf('# ') == 0) {
+                    if (currentSection) {
+                        window.sections.push(currentSection.join("\n"));
+                    }
+                    // console.log("slide header found: " + line);
+                    currentSection = Array();
+                    currentSection.push('<pre>');
+                    currentSection.push(line);
+                } else {
+                    if (currentSection) {
+                        currentSection.push(line);
+                    }
+                }
+            }
+            window.sections.push(currentSection.join("\n"));
+            console.log(window.sections);
+        }
+
+        document.getElementById('deck').onload = function(event) {
+            var sourceDoc = source.contentDocument;
+            split_source(sourceDoc.documentElement);
+            var deckWindow = deck.contentWindow;
+            var update_source = function() {
+                // console.log("updating source view");
+                var slideNr = deckWindow.Reveal.getIndices().h;
+                source.contentDocument.documentElement.innerHTML = '<div style="padding-left: 1em; position: relative; top: 50%; transform: translateY(-50%);"><em>slide source</em></br></br>' + window.sections[slideNr] + "</div>";
+            };
+            update_source();
+            deckWindow.Reveal.addEventListener('slidechanged', update_source);
+            deckWindow.focus();
+        };
+    </script>
+</body>
+</html>
+EOF
+
+    cat > assets/css/slides.scss << "EOF"
+/* put your styles in this file */
+EOF
+
+    echo "Yay, go ahead and create you presentation!"
+    echo "Write the slides in Markdown in slides.md"
+    echo "Store images and styles in assets/"
+    echo "Run '$(basename "${0}")' to compile the presentation"
+}
+
+startMarkdeck () {
+    createFolder "${BUILD}"
+    testOwnership "${BUILD}"
+    MARKDECK_USER=$(stat -c %u:%g "${BUILD}") dockerCompose up
+}
+
+if [ $# -ge 1 ]; then
+    case "${1}" in
+        'scaffold' )
+            scaffold
+            ;;
+        'pull' )
+            dockerCompose pull
+            ;;
+        'stop' )
+            dockerCompose down
+            ;;
+        'update' )
+            update
+            ;;
+        '-h' | '--help' )
+            printHelp
+            ;;
+        '-v' | '--version' )
+            printVersion
+            ;;
+        'start' )
+            startMarkdeck
+            ;;
+        * )
+            printHelp
+            exit 1
+            ;;
+    esac
+else
+    startMarkdeck
+fi

--- a/markdeck
+++ b/markdeck
@@ -4,6 +4,7 @@ set -ue
 
 BUILD=deck
 VERSION=0.1
+PORT=8080
 
 printHelp () {
     echo "$(basename "$0") [-h|--help|-v|--version] [command]"
@@ -45,20 +46,20 @@ services:
     user: "\$MARKDECK_USER"
     volumes:
       - type: bind
-        source: $PWD/
+        source: ${PWD}/
         target: /source
         read_only: true
       - type: bind
-        source: $PWD/$BUILD
+        source: ${PWD}/${BUILD}
         target: /target
 
   web:
     image: "arne/markdeck-liveserver:0.2"
     ports:
-      - "8080:8080"
+      - "${PORT}:8080"
     volumes:
       - type: bind
-        source: $PWD/$BUILD
+        source: ${PWD}/${BUILD}
         target: /target
     depends_on: [markdeck]
 
@@ -66,7 +67,7 @@ services:
     image: "arne/markdeck-decktape:0.5"
     volumes:
       - type: bind
-        source: $PWD/$BUILD
+        source: ${PWD}/${BUILD}
         target: /slides
     shm_size: 1G
     depends_on: [markdeck, web]
@@ -75,20 +76,20 @@ services:
     image: "arne/markdeck-standalone:0.2"
     volumes:
       - type: bind
-        source: $PWD/$BUILD
+        source: ${PWD}/${BUILD}
         target: /target
     depends_on: [web]
 
   helper:
     image: "arne/markdeck-helper:0.2"
     ports:
-      - "8081:8081"
+      - "$((${PORT}+1)):8081"
 
   a2sketch:
     image: "arne/a2sketch:0.11"
     volumes:
       - type: bind
-        source: $PWD/a2s-custom-types
+        source: ${PWD}/a2s-custom-types
         target: /custom-types
         read_only: true
 EOF

--- a/markdeck
+++ b/markdeck
@@ -110,8 +110,10 @@ update () {
 }
 
 scaffold () {
-    mkdir -p assets/css
     if [ ! -e slides.md ]; then
+        mkdir -p assets/css
+
+        echo "Creating slides.md"
         cat > slides.md << "EOF"
 ---
 title: markdeck scaffold
@@ -140,10 +142,10 @@ interesting links:
 
 ⚪ ⚪ ⚪
 EOF
-    if
 
-    if [ ! -e assets/explain.html ]; then
-        cat > assets/explain.html << "EOF"
+        if [ ! -e assets/explain.html ]; then
+            echo "Creating assets/explain.html"
+            cat > assets/explain.html << "EOF"
 <html>
 <head>
     <style>
@@ -242,18 +244,23 @@ EOF
 </body>
 </html>
 EOF
-    fi
+        fi
 
-    if [ ! -e assets/css/slides.scss ]; then
-        cat > assets/css/slides.scss << "EOF"
+        if [ ! -e assets/css/slides.scss ]; then
+            echo "Creating assets/css/slides.scss"
+            cat > assets/css/slides.scss << "EOF"
 /* put your styles in this file */
 EOF
-    fi
+        fi
 
-    echo "Yay, go ahead and create you presentation!"
-    echo "Write the slides in Markdown in slides.md"
-    echo "Store images and styles in assets/"
-    echo "Run '$(basename "${0}")' to compile the presentation"
+        echo "Yay, go ahead and create you presentation!"
+        echo "Write the slides in slides.md"
+        echo "Store images and styles in assets/"
+        echo "Run '$(basename "${0}")' to compile the presentation"
+    else
+        echo "No scaffolding needed, there's already a presentation in this folder (slides.md)"
+        echo "Run '$(basename "${0}")' to compile the presentation"
+    fi
 }
 
 startMarkdeck () {

--- a/markdeck
+++ b/markdeck
@@ -106,15 +106,16 @@ dockerCompose () {
 update () {
     curl -# -S -f -L -O "${0}" https://raw.githubusercontent.com/arnehilmann/markdeck/master/markdeck
     chmod a+x "${0}"
-    echo "Updated from $(printVersion) to $("${0}" --version)"
+    echo "Updated from $(printVersion) to $("${0}" --version)."
 }
 
 scaffold () {
-    if [ ! -e slides.md ]; then
+    if ! isPresentationFolder; then
         mkdir -p assets/css
 
-        echo "Creating slides.md"
-        cat > slides.md << "EOF"
+        if [ ! -e slides.md ]; then
+            echo "Creating slides.md."
+            cat > slides.md << "EOF"
 ---
 title: markdeck scaffold
 pdf: markdeck-scaffold.pdf
@@ -142,9 +143,10 @@ interesting links:
 
 ⚪ ⚪ ⚪
 EOF
+        fi
 
         if [ ! -e assets/explain.html ]; then
-            echo "Creating assets/explain.html"
+            echo "Creating assets/explain.html."
             cat > assets/explain.html << "EOF"
 <html>
 <head>
@@ -247,23 +249,37 @@ EOF
         fi
 
         if [ ! -e assets/css/slides.scss ]; then
-            echo "Creating assets/css/slides.scss"
+            echo "Creating assets/css/slides.scss."
             cat > assets/css/slides.scss << "EOF"
 /* put your styles in this file */
 EOF
         fi
 
         echo "Yay, go ahead and create you presentation!"
-        echo "Write the slides in slides.md"
-        echo "Store images and styles in assets/"
-        echo "Run '$(basename "${0}")' to compile the presentation"
+        echo "Write the slides in slides.md."
+        echo "Store images and styles in assets/."
+        echo "Run '$(basename "${0}")' to compile the presentation."
     else
-        echo "No scaffolding needed, there's already a presentation in this folder (slides.md)"
-        echo "Run '$(basename "${0}")' to compile the presentation"
+        echo "No scaffolding needed, there's already a presentation in this folder (slides.md)."
+        echo "Run '$(basename "${0}")' to compile the presentation."
+        return 1
     fi
 }
 
+isPresentationFolder () {
+    shopt -s nullglob
+    res=1
+    [ -n "$(echo ${1:-.}/slide*.md)" ] && res=0
+    shopt -u nullglob
+    return $res
+}
+
 startMarkdeck () {
+    if ! isPresentationFolder; then
+        echo "This folder doesn't contain a markdeck presentation." 1>&2
+        echo "Run '$(basename "${0}") scaffold' to create one." 1>&2
+        return 1
+    fi
     createFolder "${BUILD}"
     testOwnership "${BUILD}"
     MARKDECK_USER=$(stat -c %u:%g "${BUILD}") dockerCompose up
@@ -300,3 +316,4 @@ if [ $# -ge 1 ]; then
 else
     startMarkdeck
 fi
+exit $?

--- a/markdeck
+++ b/markdeck
@@ -111,7 +111,8 @@ update () {
 
 scaffold () {
     mkdir -p assets/css
-    cat > slides.md << "EOF"
+    if [ ! -e slides.md ]; then
+        cat > slides.md << "EOF"
 ---
 title: markdeck scaffold
 pdf: markdeck-scaffold.pdf
@@ -239,10 +240,13 @@ EOF
 </body>
 </html>
 EOF
+    fi
 
-    cat > assets/css/slides.scss << "EOF"
+    if [ ! -e assets/css/slides.scss ]; then
+        cat > assets/css/slides.scss << "EOF"
 /* put your styles in this file */
 EOF
+    fi
 
     echo "Yay, go ahead and create you presentation!"
     echo "Write the slides in Markdown in slides.md"

--- a/markdeck
+++ b/markdeck
@@ -140,8 +140,10 @@ interesting links:
 
 ⚪ ⚪ ⚪
 EOF
+    if
 
-    cat > assets/explain.html << "EOF"
+    if [ ! -e assets/explain.html ]; then
+        cat > assets/explain.html << "EOF"
 <html>
 <head>
     <style>


### PR DESCRIPTION
I created a script that includes the `docker-compose.yml` configuration and replaces the `scaffold`, `start` and `stop` scripts. Furthermore, it cuts down the boilerplate in the presentation folder by leaving it solely for the presentation and the `./deck` build folder.